### PR TITLE
Reorganizar o SQL

### DIFF
--- a/zirix-data/zirix.sql
+++ b/zirix-data/zirix.sql
@@ -61,17 +61,6 @@ CREATE TABLE IF NOT EXISTS `twitter_accounts` (
   UNIQUE KEY `username` (`username`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
-CREATE TABLE IF NOT EXISTS `twitter_likes` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `authorId` int(11) DEFAULT NULL,
-  `tweetId` int(11) DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `FK_twitter_likes_twitter_accounts` (`authorId`),
-  KEY `FK_twitter_likes_twitter_tweets` (`tweetId`),
-  CONSTRAINT `FK_twitter_likes_twitter_accounts` FOREIGN KEY (`authorId`) REFERENCES `twitter_accounts` (`id`),
-  CONSTRAINT `FK_twitter_likes_twitter_tweets` FOREIGN KEY (`tweetId`) REFERENCES `twitter_tweets` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
-
 CREATE TABLE IF NOT EXISTS `twitter_tweets` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `authorId` int(11) NOT NULL,
@@ -83,6 +72,66 @@ CREATE TABLE IF NOT EXISTS `twitter_tweets` (
   KEY `FK_twitter_tweets_twitter_accounts` (`authorId`),
   CONSTRAINT `FK_twitter_tweets_twitter_accounts` FOREIGN KEY (`authorId`) REFERENCES `twitter_accounts` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+CREATE TABLE IF NOT EXISTS `twitter_likes` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `authorId` int(11) DEFAULT NULL,
+  `tweetId` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK_twitter_likes_twitter_accounts` (`authorId`),
+  KEY `FK_twitter_likes_twitter_tweets` (`tweetId`),
+  CONSTRAINT `FK_twitter_likes_twitter_accounts` FOREIGN KEY (`authorId`) REFERENCES `twitter_accounts` (`id`),
+  CONSTRAINT `FK_twitter_likes_twitter_tweets` FOREIGN KEY (`tweetId`) REFERENCES `twitter_tweets` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS `vrp_users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `whitelisted` tinyint(1) DEFAULT NULL,
+  `banned` tinyint(1) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE IF NOT EXISTS `vrp_user_ids` (
+  `identifier` varchar(100) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`identifier`),
+  KEY `fk_user_ids_users` (`user_id`),
+  CONSTRAINT `fk_user_ids_users` FOREIGN KEY (`user_id`) REFERENCES `vrp_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE IF NOT EXISTS `vrp_user_identities` (
+  `user_id` int(11) NOT NULL,
+  `registration` varchar(20) DEFAULT NULL,
+  `phone` varchar(20) DEFAULT NULL,
+  `firstname` varchar(50) DEFAULT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `age` int(11) DEFAULT NULL,
+  `foto` varchar(200) DEFAULT NULL,
+  `foragido` int(1) NOT NULL DEFAULT 0,
+  `licensa` int(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`),
+  KEY `registration` (`registration`),
+  KEY `phone` (`phone`),
+  CONSTRAINT `fk_user_identities_users` FOREIGN KEY (`user_id`) REFERENCES `vrp_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE IF NOT EXISTS `vrp_user_data` (
+  `user_id` int(11) NOT NULL,
+  `dkey` varchar(100) NOT NULL,
+  `dvalue` text DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`dkey`),
+  CONSTRAINT `fk_user_data_users` FOREIGN KEY (`user_id`) REFERENCES `vrp_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE IF NOT EXISTS `vrp_user_homes` (
+  `user_id` int(11) NOT NULL,
+  `home` varchar(255) NOT NULL,
+  `number` int(11) DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`home`),
+  CONSTRAINT `fk_user_homes_users` FOREIGN KEY (`user_id`) REFERENCES `vrp_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 
 CREATE TABLE IF NOT EXISTS `vrp_business` (
   `user_id` int(11) NOT NULL,
@@ -110,53 +159,6 @@ CREATE TABLE IF NOT EXISTS `vrp_srv_data` (
   `dkey` varchar(100) NOT NULL,
   `dvalue` text DEFAULT NULL,
   PRIMARY KEY (`dkey`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-CREATE TABLE IF NOT EXISTS `vrp_users` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `whitelisted` tinyint(1) DEFAULT NULL,
-  `banned` tinyint(1) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-CREATE TABLE IF NOT EXISTS `vrp_user_data` (
-  `user_id` int(11) NOT NULL,
-  `dkey` varchar(100) NOT NULL,
-  `dvalue` text DEFAULT NULL,
-  PRIMARY KEY (`user_id`,`dkey`),
-  CONSTRAINT `fk_user_data_users` FOREIGN KEY (`user_id`) REFERENCES `vrp_users` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-CREATE TABLE IF NOT EXISTS `vrp_user_homes` (
-  `user_id` int(11) NOT NULL,
-  `home` varchar(255) NOT NULL,
-  `number` int(11) DEFAULT NULL,
-  PRIMARY KEY (`user_id`,`home`),
-  CONSTRAINT `fk_user_homes_users` FOREIGN KEY (`user_id`) REFERENCES `vrp_users` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-CREATE TABLE IF NOT EXISTS `vrp_user_identities` (
-  `user_id` int(11) NOT NULL,
-  `registration` varchar(20) DEFAULT NULL,
-  `phone` varchar(20) DEFAULT NULL,
-  `firstname` varchar(50) DEFAULT NULL,
-  `name` varchar(50) DEFAULT NULL,
-  `age` int(11) DEFAULT NULL,
-  `foto` varchar(200) DEFAULT NULL,
-  `foragido` int(1) NOT NULL DEFAULT 0,
-  `licensa` int(1) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`user_id`),
-  KEY `registration` (`registration`),
-  KEY `phone` (`phone`),
-  CONSTRAINT `fk_user_identities_users` FOREIGN KEY (`user_id`) REFERENCES `vrp_users` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-CREATE TABLE IF NOT EXISTS `vrp_user_ids` (
-  `identifier` varchar(100) NOT NULL,
-  `user_id` int(11) DEFAULT NULL,
-  PRIMARY KEY (`identifier`),
-  KEY `fk_user_ids_users` (`user_id`),
-  CONSTRAINT `fk_user_ids_users` FOREIGN KEY (`user_id`) REFERENCES `vrp_users` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE TABLE IF NOT EXISTS `vrp_user_moneys` (


### PR DESCRIPTION
Reorganizei o SQL para que o phpmyadmin/heidisql não retorne erros em relação as databases linkadas em cadeia (VRP_USERS, VRP_USER_IDS, TWITTER, ETC...)
Antes o phpmyadmin retornava alguns erros de sql por causa da linkagem do vrp_user_ids com vrp_users e também com twitter_accounts e twitter_tweets.